### PR TITLE
Fix wheel compatibility matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 bin
 develop-eggs
 dist
+*.pyc
+*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ name = 'buildout.wheel'
 version = '0.1.3.dev0'
 
 install_requires = [
-    'zc.buildout >=2.8', 'setuptools', 'wheel', 'humpty', 'six']
+    'zc.buildout >=2.8', 'setuptools', 'wheel', 'humpty', 'six', 'pip']
 extras_require = dict(test=[])
 
 entry_points = """

--- a/src/buildout/wheel/__init__.py
+++ b/src/buildout/wheel/__init__.py
@@ -44,8 +44,9 @@ def interpret_distro_name(
                 return orig_interpret_distro_name(
                     location, wf.distinfo_name[:-10], metadata,
                     py_version=py_version,
-                    precedence=3, # 0 because we want wheels to be
-                                  # prefered over source
+                    # EGG_DIST since we want wheels to be prefered over source,
+                    # and we'll turn them into eggs anyway:
+                    precedence=pkg_resources.EGG_DIST,
                     platform=platform)
             else:
                 # Not a match, short circuit:


### PR DESCRIPTION
It wasn't working for manylinux1 wheels so use pep425tags from pip.

Also, since we're monkeypatching stuff, might as well fix distlib matching.

And remove a bunch of now unnecessary code.