### PR TITLE
Humpty had a great fall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 3.5
   - 3.4
 install:
-  - pip install -U pip setuptools zc.buildout
+  - pip install -U pip setuptools git+https://github.com/buildout/buildout.git@encapsulate-easy-install-env#egg=zc.buildout
   - buildout parts=test
 script: bin/test
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 3.5
   - 3.4
 install:
-  - pip install -U pip setuptools git+https://github.com/buildout/buildout.git@encapsulate-easy-install-env#egg=zc.buildout
+  - pip install -U pip setuptools zc.buildout
   - buildout parts=test
 script: bin/test
 cache:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ name = 'buildout.wheel'
 version = '0.1.3.dev0'
 
 install_requires = [
-    'zc.buildout >=2.8', 'setuptools', 'wheel', 'humpty', 'six', 'pip']
+    'zc.buildout >=2.8', 'setuptools', 'wheel', 'six', 'pip']
 extras_require = dict(test=[])
 
 entry_points = """

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,9 @@ extras_require = dict(test=[])
 entry_points = """
 [zc.buildout.extension]
 wheel = buildout.wheel:load
+
+[zc.buildout.unloadextension]
+wheel = buildout.wheel:unload
 """
 
 from setuptools import setup

--- a/src/buildout/wheel/__init__.py
+++ b/src/buildout/wheel/__init__.py
@@ -1,4 +1,5 @@
 import glob
+import logging
 import os
 import os.path
 import shutil
@@ -13,6 +14,8 @@ import zc.buildout.easy_install
 import distutils.command.install
 
 
+logger = logging.getLogger(__name__)
+
 NAMESPACE_STUB_PATH = os.path.join(os.path.dirname(__file__),
                                    'namespace_stub.py')
 assert os.path.isfile(NAMESPACE_STUB_PATH)
@@ -23,105 +26,148 @@ original_wheel_to_egg = zc.buildout.easy_install.wheel_to_egg
 orig_Installer = zc.buildout.easy_install.Installer
 
 
+def _get_dest_dist_paths(dest):
+    p = os.path
+    eggs = glob.glob(p.join(dest, '*.egg'))
+    dists = [p.dirname(dist_info) for dist_info in
+             glob.glob(p.join(dest, '*', '*.dist-info'))]
+    # sort them like pkg_resources.find_on_path() would
+    return pkg_resources._by_version_descending(set(eggs + dists))
+
+
+class Environment(pkg_resources.Environment):
+    """
+    An pkg_resources.Environment specialiation that knows how to scan all
+    dists under `eggs-directory`, regardless of whether they're actual eggs.
+    """
+
+    def __init__(self, search_path, dest):
+        self.__dest = pkg_resources.normalize_path(dest)
+        pkg_resources.Environment.__init__(self, search_path)
+
+    def scan(self, search_path=None):
+        # replace `self.__dest` (the `eggs-directory`) inside `search_path`
+        # with all distributions (egg or otherwise) located in `self.__dest`
+        # since `pkg_resources.Environment` can detect eggs in `self.__dest`,
+        # but not other kinds of dists:
+        if (search_path and
+                pkg_resources.normalize_path(search_path[0]) == self.__dest):
+            search_path[0:1] = _get_dest_dist_paths(self.__dest)
+        return pkg_resources.Environment.scan(self, search_path)
+
+    def add(self, dist):
+        # pkg_resources.find_on_path(), used by self.scan() via
+        # find_distributions(), creates all non-.egg dists as
+        # precedence=DEVELOP_DIST.
+        # Fix precedence to EGG_DIST of all packages under `self.__dest`
+        if dist.location.startswith(self.__dest + '/'):
+            dist.precedence = pkg_resources.EGG_DIST
+        return pkg_resources.Environment.add(self, dist)
+
+
 class Installer(orig_Installer):
-    """Installer class that enriches the environment with all the wheels in the
-    egg directory, since `Environment` can't find them on its own like it can
-    find eggs.
+    """
+    zc.buildout.easy_install.Installer class that feeds all dists in
+    `eggs-directory` to `pkg_resources.Environment`, not just the eggs that
+    `Environment` would auto-detect.
     """
 
     def __init__(self, *args, **kwargs):
         orig_Installer.__init__(self, *args, **kwargs)
-        dest = self._dest
-        # include unpacked wheel directories in path after `self._dest`:
-        wheeldirs = [
-            wheeldir for wheeldir in glob.glob(os.path.join(dest, '*.whl'))
-            if os.path.isdir(wheeldir)
-        ]
-        path = self._path
-        path[1:1] = wheeldirs
         # Sorry to throw away all the previous hard work creating self._env
-        # but it didn't take the wheel directories into account:
-        self._env = pkg_resources.Environment(path)
-
-
-class SelfDestructingDistro(pkg_resources.DistInfoDistribution):
-    """Since the location for creating the egg is inside the download directory
-    which could be the download cache, this wheel was created in a tempdir
-    inside it and we must clean up the tempdir to avoid leaving garbage behind.
-    """
-    def __del__(self):
-        shutil.rmtree(os.path.dirname(self.location))
+        # but we need to replace it with our special Environment.
+        self._env = Environment(self._path, dest=self._dest)
 
 
 class WheelDir(wheel.install.WheelFile):
+    """
+    WheelFile that can:
+
+     * return a DistInfoDistribution that buildout can install
+
+     * install itself into a directory and return the respective
+       `DistInfoDistribution`.
+    """
+
+    _dist_extension = '.dist'
 
     def __init__(self, *args, **kwargs):
         # use pip's notion of supported tags, not wheel's:
         kwargs.setdefault('context', pip.pep425tags.get_supported)
         super(WheelDir, self).__init__(*args, **kwargs)
 
-    def get_temp_dist(self):
-        join = os.path.join
-        target = tempfile.mkdtemp()
-        location = join(target, os.path.basename(self.filename))
+    def install_into(self, target):
+        p = os.path
+        distname = (p.splitext(p.basename(self.filename))[0] +
+                    self._dist_extension)
+        location = p.join(target, distname)
         # drop everything inside the metadata directory, keyed by section name,
         # except the code itself:
         overrides = {
             key: (location if key in ('platlib', 'purelib')
-                  else join(location, self.distinfo_name, key))
+                  else p.join(location, self.distinfo_name, key))
             for key in distutils.command.install.SCHEME_KEYS
         }
         self.install(overrides=overrides)
 
         metadata = pkg_resources.PathMetadata(
-            location, join(location, self.distinfo_name)
+            location, p.join(location, self.distinfo_name)
         )
         # Fix namespaces missing __init__ for Python 2 since we're not feeding
         # the wheel dirs to `site.addsitedir()` and so will ignore .pth files
         # in the wheel dirs.
         if (sys.version_info < (3, 3) and
                 metadata.has_metadata('namespace_packages.txt')):
-            for namespace in metadata.get_metadata_lines('namespace_packages.txt'):
-                __init__filename = namespace.split('.') + ['__init__.py']
-                dest = join(location, *__init__filename)
-                if not os.path.exists(dest):
-                    shutil.copyfile(NAMESPACE_STUB_PATH, dest)
-        # See docstring of SelfDestructingDistro above for why it's needed:
-        dist = self.distribution(location, metadata=metadata,
-                                 class_=SelfDestructingDistro)
-        return dist
+            self._plant_namespace_declarations(location, metadata)
+        return self.distribution(location, metadata=metadata)
+
+    def _plant_namespace_declarations(self, root, metadata):
+        base = [root]
+        init = ['__init__.py']
+        for namespace in metadata.get_metadata_lines('namespace_packages.txt'):
+            __init__filename = base + namespace.split('.') + init
+            dest = os.path.join(*__init__filename)
+            if not os.path.exists(dest):
+                shutil.copyfile(NAMESPACE_STUB_PATH, dest)
 
     @wheel.decorator.reify
     def distribution_info(self):
         info = self.parsed_filename.groupdict()
-        if info['plat'] == 'any':
+        if info['plat'] == 'any' and info['abi'] == 'none':
             # Pure Python
             info['plat'] = None
         elif self.compatible:
-            # abi/platform specific, but compatible wheel. Pretend we're a
-            # perfect match to avoid setuptool ignoring the wheel since it
-            # doesn't understand, e.g. manylinux1.
+            # compatible but abi/platform-specific wheel. Pretend we're a
+            # perfect platform match to avoid pkg_resources ignoring the dist
+            # since it doesn't understand, e.g. manylinux1.
             info['plat'] = pkg_resources.get_build_platform()
+        else:
+            # force pkg_resources to ignore this wheel
+            # I just hope someone doesn't invent an arch called `incompatible`
+            # just to troll us.
+            info['plat'] = 'incompatible'
         return info
 
-    def distribution(self, location=None, metadata=None,
-                     class_=pkg_resources.DistInfoDistribution):
+    def distribution(self, location=None, metadata=None):
         info = self.distribution_info
-        return class_(
+        return pkg_resources.DistInfoDistribution(
             location=location if location is not None else self.filename,
             metadata=metadata,
             project_name=info['name'],
             version=info['ver'],
             platform=info['plat'],
-            # make sure buildout believes it's an egg with anoter extension:
+            # trick buildout into believing this dist is an egg with anoter
+            # extension so it copies the dist into `eggs-directory`:
             precedence=pkg_resources.EGG_DIST,
         )
 
 
 def distros_for_location(location, basename, metadata=None):
-    """Yield egg or source distribution objects based on basename
+    """
+    Yield egg or source distribution objects based on basename.
 
-    Here we override to give wheels a chance"""
+    Here we override to give wheels a chance.
+    """
     if basename.endswith('.whl'):
         try:
             wf = WheelDir(basename)
@@ -129,7 +175,7 @@ def distros_for_location(location, basename, metadata=None):
             pass
         else:
             if wf.compatible:
-                # It's a match. Treat it as an egg
+                # It's a match. Treat it as an egg-like
                 # distro. Buildout will sort it out.
                 return [wf.distribution(location, metadata)]
         # Not a match, short circuit:
@@ -137,14 +183,37 @@ def distros_for_location(location, basename, metadata=None):
     return orig_distros_for_location(location, basename, metadata=metadata)
 
 
+_temp_dirs = []
+
+
 def wheel_to_egg(dist, tmp):
     # Ignore `tmp`. It could be the download cache and using it for anything
     # other than creating tempdirs as subdirectories risks collisions
     # between buildout runs using a shared download cache.
-    return WheelDir(dist.location).get_temp_dist()
+    # See https://github.com/buildout/buildout/issues/345
+    # Instead, create the egg-like dist in a tempdir and set it to be cleaned
+    # up when the dist goes out of scope.
+    target = tempfile.mkdtemp()
+    _temp_dirs.append(target)
+    dist = WheelDir(dist.location).install_into(target)
+
+    return dist
 
 
 def load(buildout):
     setuptools.package_index.distros_for_location = distros_for_location
     zc.buildout.easy_install.Installer = Installer
     zc.buildout.easy_install.wheel_to_egg = wheel_to_egg
+    logger.debug('Patched in wheel support')
+
+
+def unload(buildout):
+    zc.buildout.easy_install.wheel_to_egg = original_wheel_to_egg
+    zc.buildout.easy_install.Installer = orig_Installer
+    setuptools.package_index.distros_for_location = orig_distros_for_location
+    if _temp_dirs:
+        logger.debug('Cleaning up temporary directories...')
+        for temp_dir in _temp_dirs:
+            shutil.rmtree(temp_dir)
+        del _temp_dirs[:]
+        logger.debug('Done.')

--- a/src/buildout/wheel/__init__.py
+++ b/src/buildout/wheel/__init__.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import os.path
 import shutil
@@ -11,32 +12,58 @@ import pip.pep425tags
 import zc.buildout.easy_install
 import distutils.command.install
 
+
 NAMESPACE_STUB_PATH = os.path.join(os.path.dirname(__file__),
                                    'namespace_stub.py')
 assert os.path.isfile(NAMESPACE_STUB_PATH)
 
+
 orig_distros_for_location = setuptools.package_index.distros_for_location
 original_wheel_to_egg = zc.buildout.easy_install.wheel_to_egg
+orig_Installer = zc.buildout.easy_install.Installer
 
-class SelfDestructingDistro(pkg_resources.Distribution):
+
+class Installer(orig_Installer):
+    """Installer class that enriches the environment with all the wheels in the
+    egg directory, since `Environment` can't find them on its own like it can
+    find eggs.
+    """
+
+    def __init__(self, *args, **kwargs):
+        orig_Installer.__init__(self, *args, **kwargs)
+        dest = self._dest
+        # include unpacked wheel directories in path after `self._dest`:
+        wheeldirs = [
+            wheeldir for wheeldir in glob.glob(os.path.join(dest, '*.whl'))
+            if os.path.isdir(wheeldir)
+        ]
+        path = self._path
+        path[1:1] = wheeldirs
+        # Sorry to throw away all the previous hard work creating self._env
+        # but it didn't take the wheel directories into account:
+        self._env = pkg_resources.Environment(path)
+
+
+class SelfDestructingDistro(pkg_resources.DistInfoDistribution):
     """Since the location for creating the egg is inside the download directory
     which could be the download cache, this wheel was created in a tempdir
-    inside it and we must take it down to avoid leaving garbage around.
+    inside it and we must clean up the tempdir to avoid leaving garbage behind.
     """
     def __del__(self):
         shutil.rmtree(os.path.dirname(self.location))
 
-class WheelFile(wheel.install.WheelFile):
+
+class WheelDir(wheel.install.WheelFile):
 
     def __init__(self, *args, **kwargs):
         # use pip's notion of supported tags, not wheel's:
         kwargs.setdefault('context', pip.pep425tags.get_supported)
-        super(WheelFile, self).__init__(*args, **kwargs)
+        super(WheelDir, self).__init__(*args, **kwargs)
 
-    def lay_egg_into(self, target):
+    def get_temp_dist(self):
         join = os.path.join
-        dest = tempfile.mkdtemp(dir=target)
-        location = join(dest, self.egg_name)
+        target = tempfile.mkdtemp()
+        location = join(target, os.path.basename(self.filename))
         # drop everything inside the metadata directory, keyed by section name,
         # except the code itself:
         overrides = {
@@ -45,55 +72,51 @@ class WheelFile(wheel.install.WheelFile):
             for key in distutils.command.install.SCHEME_KEYS
         }
         self.install(overrides=overrides)
-        # pkg_resources special-cases directories in sys.path with `.egg`
-        # extension and expect their metadata directory to be called EGG-INFO
-        # instead of the `[name]-[version].dist-info` directory of wheels.
-        egg_info_location = join(location, 'EGG-INFO')
-        os.rename(join(location, self.distinfo_name), egg_info_location)
-        # See docstring of SelfDestructingDistro above for why it's needed:
-        metadata = pkg_resources.PathMetadata(location, egg_info_location)
-        egg = self.distribution(location, metadata=metadata,
-                                class_=SelfDestructingDistro)
-        # Fix namespaces with missing __init__
+
+        metadata = pkg_resources.PathMetadata(
+            location, join(location, self.distinfo_name)
+        )
+        # Fix namespaces missing __init__ for Python 2 since we're not feeding
+        # the wheel dirs to `site.addsitedir()` and so will ignore .pth files
+        # in the wheel dirs.
         if (sys.version_info < (3, 3) and
-                egg.has_metadata('namespace_packages.txt')):
-            for namespace in egg.get_metadata_lines('namespace_packages.txt'):
+                metadata.has_metadata('namespace_packages.txt')):
+            for namespace in metadata.get_metadata_lines('namespace_packages.txt'):
                 __init__filename = namespace.split('.') + ['__init__.py']
                 dest = join(location, *__init__filename)
                 if not os.path.exists(dest):
                     shutil.copyfile(NAMESPACE_STUB_PATH, dest)
-        return egg
+        # See docstring of SelfDestructingDistro above for why it's needed:
+        dist = self.distribution(location, metadata=metadata,
+                                 class_=SelfDestructingDistro)
+        return dist
 
     @wheel.decorator.reify
-    def egg_name(self):
-        return self.distribution().egg_name() + '.egg'
-
-    @wheel.decorator.reify
-    def is_platform_specific(self):
-        return (self.parsed_filename.group('abi') != 'none' or
-                self.parsed_filename.group('plat') != 'any')
-
-    @wheel.decorator.reify
-    def egg_platform(self):
-        if self.compatible and self.is_platform_specific:
-            # pretend we're a perfect match to avoid issues
-            # TODO: is this really necessary for buildout? Will buildout ignore
-            # manylinux1_x86_64 eggs in it's own eggs directory?
-            return pkg_resources.get_build_platform()
-        else:
-            plat = self.parsed_filename.group('plat')
-            return plat if plat != 'any' else None
+    def distribution_info(self):
+        info = self.parsed_filename.groupdict()
+        if info['plat'] == 'any':
+            # Pure Python
+            info['plat'] = None
+        elif self.compatible:
+            # abi/platform specific, but compatible wheel. Pretend we're a
+            # perfect match to avoid setuptool ignoring the wheel since it
+            # doesn't understand, e.g. manylinux1.
+            info['plat'] = pkg_resources.get_build_platform()
+        return info
 
     def distribution(self, location=None, metadata=None,
-                     class_=pkg_resources.Distribution):
-        parsed = self.parsed_filename.groupdict()
+                     class_=pkg_resources.DistInfoDistribution):
+        info = self.distribution_info
         return class_(
             location=location if location is not None else self.filename,
             metadata=metadata,
-            project_name=parsed['name'],
-            version=parsed['ver'],
-            platform=self.egg_platform,
+            project_name=info['name'],
+            version=info['ver'],
+            platform=info['plat'],
+            # make sure buildout believes it's an egg with anoter extension:
+            precedence=pkg_resources.EGG_DIST,
         )
+
 
 def distros_for_location(location, basename, metadata=None):
     """Yield egg or source distribution objects based on basename
@@ -101,7 +124,7 @@ def distros_for_location(location, basename, metadata=None):
     Here we override to give wheels a chance"""
     if basename.endswith('.whl'):
         try:
-            wf = WheelFile(basename)
+            wf = WheelDir(basename)
         except wheel.install.BadWheelFile:
             pass
         else:
@@ -113,10 +136,15 @@ def distros_for_location(location, basename, metadata=None):
         return ()
     return orig_distros_for_location(location, basename, metadata=metadata)
 
+
 def wheel_to_egg(dist, tmp):
-    wf = WheelFile(dist.location)
-    return wf.lay_egg_into(tmp)
+    # Ignore `tmp`. It could be the download cache and using it for anything
+    # other than creating tempdirs as subdirectories risks collisions
+    # between buildout runs using a shared download cache.
+    return WheelDir(dist.location).get_temp_dist()
+
 
 def load(buildout):
     setuptools.package_index.distros_for_location = distros_for_location
+    zc.buildout.easy_install.Installer = Installer
     zc.buildout.easy_install.wheel_to_egg = wheel_to_egg

--- a/src/buildout/wheel/__init__.py
+++ b/src/buildout/wheel/__init__.py
@@ -3,44 +3,67 @@ import humpty
 import os
 import pkg_resources
 import setuptools.package_index
-from six.moves.urllib import parse
 import wheel.install
+import wheel.decorator
 import pip.pep425tags
 import zc.buildout.easy_install
 
-orig_interpret_distro_name = setuptools.package_index.interpret_distro_name
+orig_distros_for_location = setuptools.package_index.distros_for_location
 original_wheel_to_egg = zc.buildout.easy_install.wheel_to_egg
 
 wheel_supported = pip.pep425tags.get_supported
+class WheelFile(wheel.install.WheelFile):
 
-def interpret_distro_name(
-    location, basename, metadata, py_version=None,
-    precedence=pkg_resources.SOURCE_DIST,
-    platform=None
-    ):
-    if '.whl' in location:
-        path = parse.urlparse(location).path
+    def __init__(self, *args, **kwargs):
+        # use pip's notion of supported tags, not wheel's:
+        kwargs.setdefault('context', pip.pep425tags.get_supported)
+        super(WheelFile, self).__init__(*args, **kwargs)
+
+    @wheel.decorator.reify
+    def is_platform_specific(self):
+        return (self.parsed_filename.group('abi') != 'none' or
+                self.parsed_filename.group('plat') != 'any')
+
+
+    @wheel.decorator.reify
+    def egg_platform(self):
+        if self.compatible and self.is_platform_specific:
+            # pretend we're a perfect match to avoid issues
+            # TODO: is this really necessary for buildout? Will buildout ignore
+            # manylinux1_x86_64 eggs in it's own eggs directory?
+            return pkg_resources.get_build_platform()
+        else:
+            plat = self.parsed_filename.group('plat')
+            return plat if plat != 'any' else None
+
+    def distribution(self, location=None, metadata=None,
+                     class_=pkg_resources.Distribution):
+        parsed = self.parsed_filename.groupdict()
+        return class_(
+            location=location if location is not None else self.filename,
+            metadata=metadata,
+            project_name=parsed['name'],
+            version=parsed['ver'],
+            platform=self.egg_platform,
+        )
+
+def distros_for_location(location, basename, metadata=None):
+    """Yield egg or source distribution objects based on basename
+
+    Here we override to give wheels a chance"""
+    if basename.endswith('.whl'):
         try:
-            wf = wheel.install.WheelFile(path, context=wheel_supported)
+            wf = WheelFile(basename)
         except wheel.install.BadWheelFile:
             pass
         else:
             if wf.compatible:
-                # It's a match. Treat it as a source
+                # It's a match. Treat it as an egg
                 # distro. Buildout will sort it out.
-                assert wf.distinfo_name.endswith('.dist-info')
-                return orig_interpret_distro_name(
-                    location, wf.distinfo_name[:-10], metadata,
-                    py_version=py_version,
-                    # EGG_DIST since we want wheels to be prefered over source,
-                    # and we'll turn them into eggs anyway:
-                    precedence=pkg_resources.EGG_DIST,
-                    platform=platform)
-            else:
-                # Not a match, short circuit:
-                return ()
-    return orig_interpret_distro_name(
-        location, basename, metadata, py_version, precedence, platform)
+                return [wf.distribution(location, metadata)]
+        # Not a match, short circuit:
+        return ()
+    return orig_distros_for_location(location, basename, metadata=metadata)
 
 def wheel_to_egg(dist, tmp):
     writer = humpty.EggWriter(dist.location)
@@ -50,7 +73,6 @@ def wheel_to_egg(dist, tmp):
         os.path.join(tmp, egg_name), egg_name)
 
 def load(buildout):
-    setuptools.package_index.EXTENSIONS.append('.whl')
-    setuptools.package_index.interpret_distro_name = interpret_distro_name
     distlib.wheel.COMPATIBLE_TAGS = set(wheel_supported())
+    setuptools.package_index.distros_for_location = distros_for_location
     zc.buildout.easy_install.wheel_to_egg = wheel_to_egg

--- a/src/buildout/wheel/__init__.py
+++ b/src/buildout/wheel/__init__.py
@@ -1,14 +1,11 @@
-import glob
 import logging
 import os
 import os.path
 import shutil
 import sys
-import tempfile
 import pkg_resources
 import setuptools.package_index
 import wheel.install
-import wheel.decorator
 import pip.pep425tags
 import zc.buildout.easy_install
 import distutils.command.install
@@ -26,74 +23,16 @@ original_wheel_to_egg = zc.buildout.easy_install.wheel_to_egg
 orig_Installer = zc.buildout.easy_install.Installer
 
 
-def _get_dest_dist_paths(dest):
-    p = os.path
-    eggs = glob.glob(p.join(dest, '*.egg'))
-    dists = [p.dirname(dist_info) for dist_info in
-             glob.glob(p.join(dest, '*', '*.dist-info'))]
-    # sort them like pkg_resources.find_on_path() would
-    return pkg_resources._by_version_descending(set(eggs + dists))
-
-
-class Environment(pkg_resources.Environment):
-    """
-    An pkg_resources.Environment specialiation that knows how to scan all
-    dists under `eggs-directory`, regardless of whether they're actual eggs.
-    """
-
-    def __init__(self, search_path, dest):
-        self.__dest = pkg_resources.normalize_path(dest)
-        pkg_resources.Environment.__init__(self, search_path)
-
-    def scan(self, search_path=None):
-        # replace `self.__dest` (the `eggs-directory`) inside `search_path`
-        # with all distributions (egg or otherwise) located in `self.__dest`
-        # since `pkg_resources.Environment` can detect eggs in `self.__dest`,
-        # but not other kinds of dists:
-        if (search_path and
-                pkg_resources.normalize_path(search_path[0]) == self.__dest):
-            search_path[0:1] = _get_dest_dist_paths(self.__dest)
-        return pkg_resources.Environment.scan(self, search_path)
-
-    def add(self, dist):
-        # pkg_resources.find_on_path(), used by self.scan() via
-        # find_distributions(), creates all non-.egg dists as
-        # precedence=DEVELOP_DIST.
-        # Fix precedence to EGG_DIST of all packages under `self.__dest`
-        if dist.location.startswith(self.__dest + '/'):
-            dist.precedence = pkg_resources.EGG_DIST
-        return pkg_resources.Environment.add(self, dist)
-
-
 class Installer(orig_Installer):
     """
-    zc.buildout.easy_install.Installer class that feeds all dists in
-    `eggs-directory` to `pkg_resources.Environment`, not just the eggs that
-    `Environment` would auto-detect, and knows how to install `wheels`.
+    zc.buildout.easy_install.Installer class that knows how to install `wheels`
     """
 
-    def __init__(self, *args, **kwargs):
-        orig_Installer.__init__(self, *args, **kwargs)
-        # Sorry to throw away all the previous hard work creating self._env
-        # but we need to replace it with our special Environment.
-        self._env = Environment(self._path, dest=self._dest)
-
-    def _call_easy_install(self, spec, ws, dest, dist):
+    def _call_easy_install(self, spec, dest):
         if not spec.endswith('.whl'):
-            return orig_Installer._call_easy_install(spec, ws, dest, dist)
-        tmp = tempfile.mkdtemp(dir=dest)
-        try:
-            # this causes the dist tree to be written twice in tempdirs inside
-            # `dest`, but the alternative would be to trick
-            # `setuptools.archive_util.unpack_archive` into unpacking wheels
-            # which requirs dealing with
-            # `setuptools.archive_util.unpack_archive.default_filter`.
-            dist = WheelInstaller(spec).install_into(tmp)
-            move = zc.buildout.easy_install._move_to_eggs_dir_and_compile
-            newloc = move(dist, dest)
-            return pkg_resources.Environment([newloc])[dist.project_name]
-        finally:
-            shutil.rmtree(tmp)
+            orig_Installer._call_easy_install(spec, dest)
+        location = WheelInstaller(spec).install_into(dest)
+        return [location]
 
 
 class WheelInstaller(object):
@@ -102,11 +41,11 @@ class WheelInstaller(object):
 
      * return a DistInfoDistribution that buildout can install
 
-     * install the wheel into a directory and return the respective
-       `DistInfoDistribution`.
+     * install the wheel into a directory to be added to `sys.path`
     """
 
     _dist_extension = '.dist'
+    wheel = None
 
     def __init__(self, location):
         # use pip's notion of supported tags, not wheel's:
@@ -114,11 +53,11 @@ class WheelInstaller(object):
         try:
             self.wheel = wheel.install.WheelFile(location, context=context)
         except wheel.install.BadWheelFile:
-            self.wheel = False
+            pass
 
     @property
     def compatible(self):
-        return self.wheel and self.wheel.compatible
+        return self.wheel is not None and self.wheel.compatible
 
     def install_into(self, target):
         """
@@ -136,32 +75,25 @@ class WheelInstaller(object):
             for key in distutils.command.install.SCHEME_KEYS
         }
         self.wheel.install(overrides=overrides)
-
-        metadata = pkg_resources.PathMetadata(
-            location, os.path.join(location, self.wheel.distinfo_name)
-        )
         # Fix namespaces missing __init__ for Python 2 since we're not feeding
         # the wheel dirs to `site.addsitedir()` and so Python will ignore .pth
         # files in the wheel dirs.
+        metadata = pkg_resources.PathMetadata(
+            location, os.path.join(location, self.wheel.distinfo_name)
+        )
+        dist = self.distribution(location, metadata=metadata)
         if (sys.version_info < (3, 3) and
                 metadata.has_metadata('namespace_packages.txt')):
-            self._plant_namespace_declarations(location, metadata)
-        # The installed distribution is egg-like to please buildout
-        return self.distribution(location, metadata=metadata,
-                                 precedence=pkg_resources.EGG_DIST)
+            self._plant_namespace_declarations(dist)
+        return dist
 
     @staticmethod
-    def _plant_namespace_declarations(root, metadata):
-        base = [root]
-        init = ['__init__.py']
-        for namespace in metadata.get_metadata_lines('namespace_packages.txt'):
-            __init__filename = os.path.join(*(
-                base + namespace.split('.') + init
-            ))
+    def _plant_namespace_declarations(dist):
+        paths = zc.buildout.easy_install.get_namespace_package_paths(dist)
+        for __init__filename in paths:
             if not os.path.exists(__init__filename):
                 shutil.copyfile(NAMESPACE_STUB_PATH, __init__filename)
 
-    @wheel.decorator.reify
     def distribution_info(self):
         """
         Parsed info from the wheel name, with a setuptools compatible platform
@@ -182,18 +114,18 @@ class WheelInstaller(object):
             info['plat'] = 'incompatible'
         return info
 
-    def distribution(self, location, metadata=None,
-                     precedence=pkg_resources.BINARY_DIST):
-        info = self.distribution_info
+    def distribution(self, location, metadata=None):
+        """ Get DistInfoDistribution for wheel """
+        info = self.distribution_info()
         return pkg_resources.DistInfoDistribution(
             location=location,
             metadata=metadata,
             project_name=info['name'],
             version=info['ver'],
             platform=info['plat'],
-            # trick buildout into believing this dist is an egg with anoter
-            # extension so it copies the dist into `eggs-directory`:
-            precedence=precedence,
+            # trick buildout into believing this dist is a BINARY_DIS
+            # so it invokes our `_call_easy_install` override:
+            precedence=pkg_resources.BINARY_DIST,
         )
 
 

--- a/src/buildout/wheel/__init__.py
+++ b/src/buildout/wheel/__init__.py
@@ -34,7 +34,7 @@ class WheelInstaller(object):
      * install the wheel into a directory to be added to `sys.path`
     """
 
-    _dist_extension = '.dist'
+    _dist_extension = '.ovo'
     wheel = None
 
     def __init__(self, location):

--- a/src/buildout/wheel/namespace_stub.py
+++ b/src/buildout/wheel/namespace_stub.py
@@ -1,0 +1,2 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/src/buildout/wheel/tests/testwheel.py
+++ b/src/buildout/wheel/tests/testwheel.py
@@ -1,11 +1,16 @@
 import os
-import pkg_resources
 import shutil
 import sys
-import tempfile
 import unittest
+import pkg_resources
 import zc.buildout.easy_install
 import zc.buildout.testing
+
+
+class Buildout(object):
+    """ Object to pass into the `load()` entry point during tests
+    """
+
 
 class BuildoutWheelTests(unittest.TestCase):
 
@@ -38,9 +43,15 @@ class BuildoutWheelTests(unittest.TestCase):
             [py, 'setup.py', 'bdist_wheel', '-d', eggs])
         os.chdir(join('..'))
 
-        import pkg_resources
+        buildout = Buildout()
         pkg_resources.load_entry_point(
-            'buildout.wheel', 'zc.buildout.extension', 'wheel')(None)
+            'buildout.wheel', 'zc.buildout.extension', 'wheel')(buildout)
+
+        @self.register_teardown
+        def unload():
+            pkg_resources.load_entry_point(
+                'buildout.wheel', 'zc.buildout.unloadextension', 'wheel'
+            )(buildout)
 
         ws = zc.buildout.easy_install.install(
             ['demo', 'extdemo'],


### PR DESCRIPTION
Drop humpty dependency.

Implements all wheel installation by subclassing `zc.buildout.easy_install.Instaler`.

Depends on merging:

- [ ] buildout/buildout#352