### PR TITLE
Add whitelist and blacklist support.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,3 +8,62 @@ wheel extension::
   [buildout]
   extensions = buildout.wheel
   ...
+
+Wheel locations and names can be blacklisted and/or whitelisted.
+If a wheel is allowed by these filters, then the wheel will be added to the list
+of potential packages considered for installation.
+
+Filtering can be achieved using the following options::
+
+  [buildout]
+  extensions = buildout.wheel
+  wheel-blacklist-locations =
+  wheel-whitelist-locations =
+  wheel-blacklist-names =
+  wheel-whitelist-names =
+
+Each option accepts a list (new-line, or comma-separated) of regular expressions
+which will be matched against the location or full wheel name (including version string).
+
+To prevent any wheels being installed from locations whose url contains ``pypi.python.org``::
+
+  [buildout]
+  extensions = buildout.wheel
+  wheel-blacklist-locations = pypi.python.org
+
+To limit which wheels will be allowed (packages starting ``foo``,
+all packages starting ``bar-1.2.3``, and packages containing ``baz-0.1.1``)::
+
+  [buildout]
+  extensions = buildout.wheel
+  wheel-whitelist-names =
+    ^foo
+    ^bar-1\.2\.3
+    baz-0\.1\.1
+
+
+Whitelists take precedence over blacklists, and names take precedence over locations.
+
+This will allow wheels from any location whose url contains ``pypi``::
+
+  [buildout]
+  extensions = buildout.wheel
+  wheel-blacklist-locations = pypi.python.org
+  wheel-whitelist-locations = pypi
+
+
+No wheels will be allowed from pypi, except for those containing ``foo`` or ``bar``::
+
+  [buildout]
+  extensions = buildout.wheel
+  wheel-blacklist-locations = pypi.python.org
+  wheel-whitelist-names = foo,bar
+
+
+Wheels will be allowed from pypi, but no wheels containing ``foo`` or ``bar``
+will be allowed from any location::
+
+  [buildout]
+  extensions = buildout.wheel
+  wheel-whitelist-locations = pypi.python.org
+  wheel-blacklist-names = foo,bar

--- a/src/buildout/wheel/__init__.py
+++ b/src/buildout/wheel/__init__.py
@@ -163,7 +163,7 @@ def load(buildout):
         filters['blacklist_names'] = config.get('wheel-blacklist-names', '').replace(',', ' ').split()
         filters['whitelist_locations'] = config.get('wheel-whitelist-locations', '').replace(',', ' ').split()
         filters['blacklist_locations'] = config.get('wheel-blacklist-locations', '').replace(',', ' ').split()
-        setuptools.package_index.distros_for_location = distros_for_location
+    setuptools.package_index.distros_for_location = distros_for_location
     buildout.old_unpack_wheel = zc.buildout.easy_install.UNPACKERS.get('.whl')
     zc.buildout.easy_install.UNPACKERS['.whl'] = unpack_wheel
     logger.debug('Patched in wheel support')

--- a/src/buildout/wheel/__init__.py
+++ b/src/buildout/wheel/__init__.py
@@ -21,7 +21,10 @@ assert os.path.isfile(NAMESPACE_STUB_PATH)
 
 orig_distros_for_location = setuptools.package_index.distros_for_location
 
-filters = {}
+filters = {'blacklist_names': [],
+           'whitelist_names': [],
+           'blacklist_locations': [],
+           'whitelist_locations': []}
 
 
 def unpack_wheel(spec, dest):

--- a/src/buildout/wheel/tests/testwheel.py
+++ b/src/buildout/wheel/tests/testwheel.py
@@ -10,7 +10,9 @@ import zc.buildout.testing
 class Buildout(object):
     """ Object to pass into the `load()` entry point during tests
     """
-
+    @staticmethod
+    def get(value, default):
+        return None
 
 class BuildoutWheelTests(unittest.TestCase):
 


### PR DESCRIPTION
This PR aims to fix #14. Explanation of how it is designed to work is in the updated README.

I've opted to set it up so that the presence of any entries in the whitelists, or the location or basename being on a blacklist, is a deny. 

After that, the location or basename being on a whitelist 're-allows' that wheel.

I think this is the most flexible approach to allowing filtering against locations and packages, but feel free to disagree, or make any other suggestions on improvements to the code.

